### PR TITLE
Create GHA to check for text in svg files

### DIFF
--- a/.github/workflows/check-svg-text.yaml
+++ b/.github/workflows/check-svg-text.yaml
@@ -1,0 +1,52 @@
+name: check-svg-text
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - 'devel'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-logo-text:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout repos
+        uses: actions/checkout@v5
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: any::xml2
+
+      - name: Check if svg contains text
+        shell: Rscript {0}
+        run: |
+          svg_logos <- list.files(
+            pattern = "\\.svg$",
+            recursive = TRUE,
+            full.names = TRUE
+          )
+          res <- svg_logos |>
+            lapply(function(x) {
+              xml2::read_xml(x) |>
+                xml2::xml_find_all("//*[starts-with(local-name(), 'text')]")
+            })
+          if (any(lengths(res) >= 1)) {
+            stop(
+              "You are adding logos that contain text. ",
+              "All text should be converted to outline. ",
+              "Problematic logos:\n  ",
+              paste(svg_logos[lengths(res) >= 1], collapse = "\n  "),
+              call. = FALSE
+            )
+          }

--- a/.github/workflows/check-svg-text.yaml
+++ b/.github/workflows/check-svg-text.yaml
@@ -5,6 +5,8 @@ on:
   pull_request:
     branches:
       - 'devel'
+    paths:
+      - '**.svg'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -28,14 +30,24 @@ jobs:
         with:
           packages: any::xml2
 
+
+      - name: Get changed svg files
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        id: changed-svg
+        run: echo "CHANGED=$(gh pr diff $PR_NUMBER --name-only | grep '\.svg$' | tr '\n' ';')" >> $GITHUB_OUTPUT
+
+
       - name: Check if svg contains text
+        env:
+          CHANGED_SVG_FILES: ${{ steps.changed-svg.outputs.CHANGED }}
         shell: Rscript {0}
         run: |
-          svg_logos <- list.files(
-            pattern = "\\.svg$",
-            recursive = TRUE,
-            full.names = TRUE
-          )
+          svg_logos <- Sys.getenv("CHANGED_SVG_FILES") |>
+            strsplit(";", fixed = TRUE) |>
+            unlist() |>
+            trimws()
           res <- svg_logos |>
             lapply(function(x) {
               xml2::read_xml(x) |>


### PR DESCRIPTION
All text should be converted to outline before publication for portability. This ensures consistent rendering across different platforms and devices, even when the used font is not available.

Next commits will ensure this only runs on changed files to avoid failures due to the fact that logos predating this change are not following this rule.

Fix #266.

Tested in https://github.com/Bisaloo/BiocStickers/pull/1 & https://github.com/Bisaloo/BiocStickers/pull/2.
